### PR TITLE
fixed Elasticsearch EC2 recreating issue 

### DIFF
--- a/main.tf
+++ b/main.tf
@@ -206,8 +206,12 @@ data "template_file" "user_data" {
   template = file("${path.module}/user_data.sh")
 }
 
+resource "aws_kms_key" "custom_kms_key" {
+  description = "Custom KMS key for EC2 encryption"
+}
+
 resource "aws_instance" "ec2_elasticsearch" {
-  count                   = !var.create_aws_elasticsearch && var.create_aws_ec2_elasticsearch ? 1 : 0
+  count                   = !var.create_aws_elasticsearch && var.create_aws_ec2_elasticsearch ? var.instance_count : 0
   ami                     = var.ami_id == "" ? data.aws_ami.amazon_linux_2.id : var.ami_id
   instance_type           = var.instance_type
   subnet_id               = var.subnet_ids[0]
@@ -226,7 +230,7 @@ resource "aws_instance" "ec2_elasticsearch" {
   root_block_device {
     delete_on_termination = var.delete_on_termination
     encrypted             = var.volume_encrypted
-    kms_key_id            = var.kms_key_id
+    kms_key_id            = aws_kms_key.custom_kms_key.arn
     volume_size           = var.volume_size
     volume_type           = var.volume_type
   }

--- a/output.tf
+++ b/output.tf
@@ -13,6 +13,9 @@ output "elasticsearch_endpoint" {
 output "kibana_endpoint" {
   value = var.create_aws_elasticsearch && !var.create_aws_ec2_elasticsearch ? aws_elasticsearch_domain.elasticsearch[0].kibana_endpoint : "undefined"
 }
+output "custom_kms_key_arn" {
+  value = aws_kms_key.custom_kms_key.arn
+}
 
 output "ec2_elasticsearch_private_ip" {
   value = !var.create_aws_elasticsearch && var.create_aws_ec2_elasticsearch ? aws_instance.ec2_elasticsearch[0].private_ip : "undefined"

--- a/userdata.yml
+++ b/userdata.yml
@@ -1,0 +1,22 @@
+#cloud-config
+
+packages:
+  - wget
+
+runcmd:
+  - wget https://artifacts.elastic.co/downloads/elasticsearch/elasticsearch-7.17.8-x86_64.rpm
+  - wget https://artifacts.elastic.co/downloads/elasticsearch/elasticsearch-7.17.8-x86_64.rpm.sha512
+  - shasum -a 512 -c elasticsearch-7.17.8-x86_64.rpm.sha512
+  - sudo rpm --install elasticsearch-7.17.8-x86_64.rpm
+  - sudo systemctl daemon-reload
+  - sudo systemctl enable elasticsearch.service
+  - sudo systemctl start elasticsearch.service
+  - |
+    echo "transport.host: localhost" >> /etc/elasticsearch/elasticsearch.yml
+    echo "transport.tcp.port: 9300" >> /etc/elasticsearch/elasticsearch.yml
+    echo "http.port: 9200" >> /etc/elasticsearch/elasticsearch.yml
+    echo "network.host: 0.0.0.0" >> /etc/elasticsearch/elasticsearch.yml
+    echo "xpack.security.enabled: false" >> /etc/elasticsearch/elasticsearch.yml
+    echo "xpack.security.transport.ssl.enabled: false" >> /etc/elasticsearch/elasticsearch.yml
+  - sudo systemctl restart elasticsearch.service
+


### PR DESCRIPTION
Change in kms key was causing replacement of EC2 instance

**Features added**

* variablised  instance block for elasticsearch EC2 creation
* kms key block added as during plan or apply kms key arn is changing for ebs even tho the alias for kms key is there,so to avoid that a custom kms key block is added for elasticsearch EC2 creation
* output of the arn is added in the output block of output.tf